### PR TITLE
Possible fix for #1

### DIFF
--- a/src/app/resume/_components/resume-form.tsx
+++ b/src/app/resume/_components/resume-form.tsx
@@ -156,6 +156,9 @@ export const educationsSchema = z.object({
       startDate: lenientDate.nullable(),
       endDate: lenientDate.nullable(),
       description: z.string(),
+    }).refine((data) => data.startDate && data.endDate && data.endDate > data.startDate, {
+      message: "End date cannot be earlier than start date.",
+      path: ["endDate"]
     })
   ),
 });
@@ -170,6 +173,9 @@ export const employmentHistorySchema = z.object({
       startDate: lenientDate.nullable(),
       endDate: lenientDate.nullable(),
       description: z.string(),
+    }).refine((data) => data.startDate && data.endDate && data.endDate > data.startDate, {
+      message: "End date cannot be earlier than start date.",
+      path: ["endDate"]
     })
   ),
 });


### PR DESCRIPTION
added zod rule for comparing enddate and startdate when both are set. Giving a descriptive error in case the end date is supplied as a date before startdate.